### PR TITLE
Add FrameShift to GUI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 
 ## GUI Tools
 
+- [FrameShift](https://gaurox.dev/frameshift/) - A free, open-source Windows GUI for FFmpeg that adds media processing actions to the Explorer right-click menu.
 - [HandBrake](https://handbrake.fr/) - A popular open-source video transcoder with FFmpeg as its core engine.
 - [Shotcut](https://shotcut.org/) - A free, open-source, cross-platform video editor that uses FFmpeg for video processing.
 - [LosslessCut](https://github.com/mifi/lossless-cut) - A simple, cross-platform tool for lossless trimming and cutting of video and audio files using FFmpeg.


### PR DESCRIPTION
[FrameShift](https://gaurox.dev/frameshift/) is a free, open-source (GPL v3) Windows GUI for FFmpeg that adds media processing actions directly to the Explorer right-click menu.

- Converts, compresses, crops, cuts, resizes and rotates video, audio and images
- Powered by FFmpeg and FFprobe (bundled — no external install)
- Also includes local AI features via ONNX Runtime: image upscaling (Real-ESRGAN), background removal, audio stem separation (HTDemucs), denoising (DeepFilterNet) and RIFE video interpolation

GitHub: https://github.com/gaurox/FrameShift